### PR TITLE
Fix segfault that can occur if zvbi returns non-contiguous CC segments

### DIFF
--- a/input/sdi/vbi.c
+++ b/input/sdi/vbi.c
@@ -149,6 +149,7 @@ int setup_vbi_parser( obe_sdi_non_display_data_t *non_display_data )
 
 #define REMOVE_LINES( num_lines ) \
     memmove( &sliced[i], &sliced[i+(num_lines)], (decoded_lines-i-(num_lines)) * sizeof(vbi_sliced) ); \
+    memset( &sliced[decoded_lines-num_lines], 0, num_lines * sizeof(vbi_sliced) ); \
     if( decoded_lines >= num_lines )  \
         decoded_lines -= num_lines; \
     i--; \


### PR DESCRIPTION
When REMOVE_LINES compacts the array, it left the old entries at the
end of the array.  Because the loop which iterates over the entries
looks at sliced[i+1].id to find the second CC entry, it may look
past the end of the valid entries and examine one of the entries
which has already been moved forward.  If this is a CC entry, the
iterator will be on the last valid entry but will try to call
REMOVE_LINES(2).  This will cause memmove() to be called with a
negative length.

Explicitly wipe the old copies of entries at the end of the list
after compaction.  This means the routine will still look past
the end of the list of valid entries, but it will never find an
entry which has the .id field set to VBI_SLICED_CAPTION_525.

The specific case seen in production was a list of three sliced
entries where the first was CC, the second was NABTS, and the third
was CC.